### PR TITLE
Fix project path in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ La aplicación permite cargar archivos Excel locales, procesar KPIs logísticos 
 ## Estructura del Proyecto
 
 ```
-PEMEX_Dashboard_Dash/
-├── app.py                  # Código principal de la aplicación Dash
+Pemex_Logistics/
+├── Pemex_Logistica.py      # Código principal de la aplicación Dash
 ├── requirements.txt        # Lista de dependencias de Python
 ├── /assets/
 │   └── style.css           # Estilos visuales personalizados
@@ -45,7 +45,7 @@ pip install -r requirements.txt
 2. Ejecuta la aplicación desde la terminal:
 
 ```
-python app.py
+python Pemex_Logistica.py
 ```
 
 3. Abre tu navegador web y accede a:


### PR DESCRIPTION
## Summary
- update project tree to `Pemex_Logistics`
- reference `Pemex_Logistica.py` as the main script

## Testing
- `python -m py_compile Pemex_Logistica.py`

------
https://chatgpt.com/codex/tasks/task_e_686989421bd883208f7825c006b5d630